### PR TITLE
chore: remove `max_retryable_transaction_duration_in_hours`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5342,6 +5342,7 @@ dependencies = [
 name = "databend-storages-common-session"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-types",

--- a/src/query/catalog/src/table_context.rs
+++ b/src/query/catalog/src/table_context.rs
@@ -349,7 +349,7 @@ pub trait TableContext: Send + Sync {
     fn txn_mgr(&self) -> TxnManagerRef;
     fn get_table_meta_timestamps(
         &self,
-        table_id: u64,
+        table: &dyn Table,
         previous_snapshot: Option<Arc<TableSnapshot>>,
     ) -> Result<TableMetaTimestamps>;
 

--- a/src/query/service/src/interpreters/interpreter_copy_into_table.rs
+++ b/src/query/service/src/interpreters/interpreter_copy_into_table.rs
@@ -114,7 +114,7 @@ impl CopyIntoTableInterpreter {
             .await?;
         let table_meta_timestamps = self
             .ctx
-            .get_table_meta_timestamps(to_table.get_id(), snapshot)?;
+            .get_table_meta_timestamps(to_table.as_ref(), snapshot)?;
         let mut update_stream_meta_reqs = vec![];
         let (source, project_columns) = if let Some(ref query) = plan.query {
             let query = if plan.enable_distributed {
@@ -266,7 +266,7 @@ impl CopyIntoTableInterpreter {
 
             let fuse_table = FuseTable::try_from_table(to_table.as_ref())?;
             let table_meta_timestamps = ctx.get_table_meta_timestamps(
-                to_table.get_id(),
+                to_table.as_ref(),
                 fuse_table.read_table_snapshot().await?,
             )?;
             to_table.commit_insertion(

--- a/src/query/service/src/interpreters/interpreter_insert.rs
+++ b/src/query/service/src/interpreters/interpreter_insert.rs
@@ -112,7 +112,7 @@ impl Interpreter for InsertInterpreter {
                 databend_common_storages_fuse::FuseTable::try_from_table(table.as_ref())?;
             let snapshot = fuse_table.read_table_snapshot().await?;
             self.ctx
-                .get_table_meta_timestamps(table.get_id(), snapshot)?
+                .get_table_meta_timestamps(table.as_ref(), snapshot)?
         } else {
             Default::default()
         };

--- a/src/query/service/src/interpreters/interpreter_insert_multi_table.rs
+++ b/src/query/service/src/interpreters/interpreter_insert_multi_table.rs
@@ -381,10 +381,9 @@ impl InsertIntoBranches {
         for table in &self.tables {
             let table_info = table.get_table_info();
             let catalog_info = ctx.get_catalog(table_info.catalog()).await?.info();
-            let snapshot = FuseTable::try_from_table(table.as_ref())?
-                .read_table_snapshot()
-                .await?;
-            let table_meta_timestamps = ctx.get_table_meta_timestamps(table.get_id(), snapshot)?;
+            let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+            let snapshot = fuse_table.read_table_snapshot().await?;
+            let table_meta_timestamps = ctx.get_table_meta_timestamps(table.as_ref(), snapshot)?;
             serializable_tables.push(SerializableTable {
                 target_catalog_info: catalog_info,
                 target_table_info: table_info.clone(),
@@ -408,10 +407,9 @@ impl InsertIntoBranches {
             }
             last_table_id = Some(table_id);
             let catalog_info = ctx.get_catalog(table_info.catalog()).await?.info();
-            let snapshot = FuseTable::try_from_table(table.as_ref())?
-                .read_table_snapshot()
-                .await?;
-            let table_meta_timestamps = ctx.get_table_meta_timestamps(table.get_id(), snapshot)?;
+            let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+            let snapshot = fuse_table.read_table_snapshot().await?;
+            let table_meta_timestamps = ctx.get_table_meta_timestamps(table.as_ref(), snapshot)?;
             serializable_tables.push(SerializableTable {
                 target_catalog_info: catalog_info,
                 target_table_info: table_info.clone(),

--- a/src/query/service/src/interpreters/interpreter_mutation.rs
+++ b/src/query/service/src/interpreters/interpreter_mutation.rs
@@ -233,7 +233,7 @@ pub async fn build_mutation_info(
     .await?;
 
     let table_meta_timestamps =
-        ctx.get_table_meta_timestamps(fuse_table.get_id(), table_snapshot.clone())?;
+        ctx.get_table_meta_timestamps(table.as_ref(), table_snapshot.clone())?;
 
     Ok(MutationBuildInfo {
         table_info,

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -175,7 +175,7 @@ impl ReplaceInterpreter {
 
         let table_meta_timestamps = self
             .ctx
-            .get_table_meta_timestamps(table_info.ident.table_id, base_snapshot.clone())?;
+            .get_table_meta_timestamps(table.as_ref(), base_snapshot.clone())?;
 
         let is_multi_node = !self.ctx.get_cluster().is_empty();
         let is_value_source = matches!(self.plan.source, InsertInputSource::Values(_));

--- a/src/query/service/src/interpreters/interpreter_table_add_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_add_column.rs
@@ -125,7 +125,7 @@ impl Interpreter for AddTableColumnInterpreter {
             let prev_snapshot_id = base_snapshot.snapshot_id().map(|(id, _)| id);
             let table_meta_timestamps = self
                 .ctx
-                .get_table_meta_timestamps(fuse_table.get_id(), base_snapshot)?;
+                .get_table_meta_timestamps(tbl.as_ref(), base_snapshot)?;
 
             // computed columns will generated from other columns.
             let new_schema = table_info.meta.schema.remove_computed_fields();
@@ -243,7 +243,7 @@ pub(crate) async fn generate_new_snapshot(
         let mut new_snapshot = TableSnapshot::try_from_previous(
             snapshot.clone(),
             Some(fuse_table.get_table_info().ident.seq),
-            ctx.get_table_meta_timestamps(fuse_table.get_id(), Some(snapshot))?,
+            ctx.get_table_meta_timestamps(fuse_table, Some(snapshot))?,
         )?;
 
         // replace schema

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -196,7 +196,7 @@ impl ModifyTableColumnInterpreter {
         let prev_snapshot_id = base_snapshot.snapshot_id().map(|(id, _)| id);
         let table_meta_timestamps = self
             .ctx
-            .get_table_meta_timestamps(fuse_table.get_id(), base_snapshot.clone())?;
+            .get_table_meta_timestamps(table.as_ref(), base_snapshot.clone())?;
 
         let mut bloom_index_cols = vec![];
         if let Some(v) = table_info.options().get(OPT_KEY_BLOOM_INDEX_COLUMNS) {

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -102,6 +102,7 @@ use databend_common_storage::StageFileInfo;
 use databend_common_storage::StageFilesInfo;
 use databend_common_storage::StorageMetrics;
 use databend_common_storages_delta::DeltaTable;
+use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::TableContext;
 use databend_common_storages_iceberg::IcebergTable;
 use databend_common_storages_orc::OrcTable;
@@ -1481,31 +1482,39 @@ impl TableContext for QueryContext {
 
     fn get_table_meta_timestamps(
         &self,
-        table_id: u64,
+        table: &dyn Table,
         previous_snapshot: Option<Arc<TableSnapshot>>,
     ) -> Result<TableMetaTimestamps> {
+        let table_id = table.get_id();
         let cache = self.shared.get_table_meta_timestamps();
         let cached_item = cache.lock().get(&table_id).copied();
-        let delta = {
-            let settings = &self.query_settings;
-            let max_exec_time_secs = settings.get_max_execute_time_in_seconds()?;
-            let duration = if max_exec_time_secs != 0 {
-                Duration::from_secs(max_exec_time_secs)
-            } else {
-                // no limit, use retention period as delta
-                Duration::from_days(settings.get_data_retention_time_in_days()?)
-            };
-
-            chrono::Duration::from_std(duration).map_err(|e| {
-                ErrorCode::Internal(format!(
-                    "Unable to construct delta duration of table meta timestamp, {e}",
-                ))
-            })?
-        };
 
         match cached_item {
             Some(ts) => Ok(ts),
             None => {
+                let delta = {
+                    let settings = &self.query_settings;
+                    let max_exec_time_secs = settings.get_max_execute_time_in_seconds()?;
+                    let duration = if max_exec_time_secs != 0 {
+                        Duration::from_secs(max_exec_time_secs)
+                    } else {
+                        // no limit, use retention period as delta
+                        let fuse_table = FuseTable::try_from_table(table)?;
+                        // prefer table-level retention setting.
+                        match fuse_table.get_table_retention_period() {
+                            None => {
+                                Duration::from_days(settings.get_data_retention_time_in_days()?)
+                            }
+                            Some(v) => v,
+                        }
+                    };
+
+                    chrono::Duration::from_std(duration).map_err(|e| {
+                        ErrorCode::Internal(format!(
+                            "Unable to construct delta duration of table meta timestamp, {e}",
+                        ))
+                    })?
+                };
                 let ts = self.txn_mgr().lock().get_table_meta_timestamps(
                     table_id,
                     previous_snapshot,

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -996,11 +996,10 @@ impl TableContext for CtxDelegation {
 
     fn get_table_meta_timestamps(
         &self,
-        table_id: u64,
+        table: &dyn Table,
         previous_snapshot: Option<Arc<TableSnapshot>>,
     ) -> Result<TableMetaTimestamps> {
-        self.ctx
-            .get_table_meta_timestamps(table_id, previous_snapshot)
+        self.ctx.get_table_meta_timestamps(table, previous_snapshot)
     }
 
     fn get_temp_table_prefix(&self) -> Result<String> {

--- a/src/query/service/tests/it/storages/fuse/meta/snapshot.rs
+++ b/src/query/service/tests/it/storages/fuse/meta/snapshot.rs
@@ -61,7 +61,7 @@ fn snapshot_timestamp_time_skew_tolerance() {
 
     // simulating a stalled clock
     prev.timestamp = Some(prev.timestamp.unwrap().add(chrono::Duration::days(1)));
-    let table_meta_timestamps = TableMetaTimestamps::new(None, 72);
+    let table_meta_timestamps = TableMetaTimestamps::new(None, chrono::Duration::hours(72));
 
     let current = TableSnapshot::try_new(
         None,

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -893,11 +893,10 @@ impl TableContext for CtxDelegation {
     }
     fn get_table_meta_timestamps(
         &self,
-        table_id: u64,
+        table: &dyn Table,
         previous_snapshot: Option<Arc<TableSnapshot>>,
     ) -> Result<TableMetaTimestamps> {
-        self.ctx
-            .get_table_meta_timestamps(table_id, previous_snapshot)
+        self.ctx.get_table_meta_timestamps(table, previous_snapshot)
     }
 }
 

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/block_compact_mutator.rs
@@ -122,7 +122,7 @@ async fn do_compact(ctx: Arc<QueryContext>, table: Arc<dyn Table>) -> Result<boo
     let table_info = table.get_table_info().clone();
     if let Some((parts, snapshot)) = res {
         let table_meta_timestamps =
-            ctx.get_table_meta_timestamps(table_info.ident.table_id, Some(snapshot.clone()))?;
+            ctx.get_table_meta_timestamps(table.as_ref(), Some(snapshot.clone()))?;
         let merge_meta = parts.partitions_type() == PartInfoType::LazyLevel;
         let root = PhysicalPlan::CompactSource(Box::new(CompactSource {
             parts,

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -186,13 +186,6 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=data_retention_time_in_days_max)),
                 }),
-                ("max_retryable_transaction_duration_in_hours", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(72),
-                    desc: "Sets the maximum retryable transaction duration in hours.",
-                    mode: SettingMode::Both,
-                    scope: SettingScope::Both,
-                    range: Some(SettingRange::Numeric(0..=240)),
-                }),
                 ("max_spill_io_requests", DefaultSettingValue {
                     value: UserSettingValue::UInt64(default_max_spill_io_requests),
                     desc: "Sets the maximum number of concurrent spill I/O requests.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -228,14 +228,6 @@ impl Settings {
         self.try_get_u64("data_retention_time_in_days")
     }
 
-    pub fn get_max_retryable_transaction_duration_in_hours(&self) -> Result<u64> {
-        self.try_get_u64("max_retryable_transaction_duration_in_hours")
-    }
-
-    pub fn set_max_retryable_transaction_duration_in_hours(&self, val: u64) -> Result<()> {
-        self.try_set_u64("max_retryable_transaction_duration_in_hours", val)
-    }
-
     pub fn get_max_storage_io_requests(&self) -> Result<u64> {
         self.try_get_u64("max_storage_io_requests")
     }

--- a/src/query/sql/src/executor/physical_plans/physical_compact_source.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_compact_source.rs
@@ -69,7 +69,7 @@ impl PhysicalPlanBuilder {
 
         let table_meta_timestamps = self
             .ctx
-            .get_table_meta_timestamps(table_info.ident.table_id, Some(snapshot.clone()))?;
+            .get_table_meta_timestamps(tbl.as_ref(), Some(snapshot.clone()))?;
 
         let merge_meta = parts.partitions_type() == PartInfoType::LazyLevel;
         let mut root = PhysicalPlan::CompactSource(Box::new(CompactSource {

--- a/src/query/sql/src/executor/physical_plans/physical_recluster.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_recluster.rs
@@ -89,7 +89,7 @@ impl PhysicalPlanBuilder {
 
             let table_meta_timestamps = self
                 .ctx
-                .get_table_meta_timestamps(tbl.get_id(), Some(snapshot.clone()))?;
+                .get_table_meta_timestamps(tbl.as_ref(), Some(snapshot.clone()))?;
 
             let plan = self.build(s_expr.child(0)?, required).await?;
             let plan = PhysicalPlan::HilbertSerialize(Box::new(HilbertSerialize {
@@ -120,7 +120,7 @@ impl PhysicalPlanBuilder {
 
             let table_meta_timestamps = self
                 .ctx
-                .get_table_meta_timestamps(tbl.get_id(), Some(snapshot.clone()))?;
+                .get_table_meta_timestamps(tbl.as_ref(), Some(snapshot.clone()))?;
 
             if parts.is_empty() {
                 return Err(ErrorCode::NoNeedToRecluster(format!(

--- a/src/query/storages/common/session/Cargo.toml
+++ b/src/query/storages/common/session/Cargo.toml
@@ -14,6 +14,7 @@ databend-common-storage = { workspace = true }
 databend-storages-common-blocks = { workspace = true }
 databend-storages-common-table-meta = { workspace = true }
 
+chrono = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 uuid = { workspace = true }

--- a/src/query/storages/common/session/src/transaction.rs
+++ b/src/query/storages/common/session/src/transaction.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use chrono::Duration;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::schema::TableCopiedFileInfo;
 use databend_common_meta_app::schema::TableIdent;
@@ -358,7 +359,7 @@ impl TxnManager {
         &mut self,
         table_id: u64,
         previous_snapshot: Option<Arc<TableSnapshot>>,
-        delta: i64,
+        delta: Duration,
     ) -> TableMetaTimestamps {
         if !self.is_active() {
             return TableMetaTimestamps::new(previous_snapshot, delta);

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -638,6 +638,20 @@ impl FuseTable {
         );
         Ok(())
     }
+
+    pub fn get_table_retention_period(&self) -> Option<std::time::Duration> {
+        self.table_info
+            .options()
+            .get(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS)
+            .map(|val| {
+                std::time::Duration::from_secs(
+                    // Data retention period should be positive, parse it to unsigned value first
+                    3600 * val
+                        .parse::<u64>()
+                        .expect("Internal error, parsing table level data retention period failed"),
+                )
+            })
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/query/storages/fuse/src/operations/analyze.rs
+++ b/src/query/storages/fuse/src/operations/analyze.rs
@@ -265,7 +265,7 @@ impl SinkAnalyzeState {
             snapshot.clone(),
             Some(table.get_table_info().ident.seq),
             self.ctx
-                .get_table_meta_timestamps(table.get_id(), Some(snapshot.clone()))?,
+                .get_table_meta_timestamps(table, Some(snapshot.clone()))?,
         )?;
         new_snapshot.summary.col_stats = col_stats;
         new_snapshot.summary.cluster_stats = cluster_stats;

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -328,7 +328,7 @@ impl FuseTable {
         // Status
         ctx.set_status_info("mutation: begin try to commit");
         let table_meta_timestamps =
-            ctx.get_table_meta_timestamps(self.get_id(), Some(base_snapshot.clone()))?;
+            ctx.get_table_meta_timestamps(self, Some(base_snapshot.clone()))?;
 
         loop {
             let mut snapshot_tobe_committed = TableSnapshot::try_from_previous(

--- a/src/query/storages/fuse/src/operations/truncate.rs
+++ b/src/query/storages/fuse/src/operations/truncate.rs
@@ -73,8 +73,7 @@ impl FuseTable {
         )?;
 
         let snapshot_gen = TruncateGenerator::new(mode);
-        let table_meta_timestamps =
-            ctx.get_table_meta_timestamps(self.get_id(), Some(prev_snapshot))?;
+        let table_meta_timestamps = ctx.get_table_meta_timestamps(self, Some(prev_snapshot))?;
         pipeline.add_sink(|input| {
             CommitSink::try_create(
                 self,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- refactor: remove setting 'max_retryable_transaction_duration_in_hours' 

  while constructing the table meta timestamp, use the value of
  `max_exec_time_secs` if it is set (not 0), otherwise use the
  value of `data_retention_time_in_days_max`.


- refactor: respect table level retention period while constructing table meta timestamp

---

- Closes #issue

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - use existing tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
